### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.8", "3.12"]
         influxdb-version: [ "2.6", "2.7" ]
       fail-fast: false
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ influxio changelog
 
 in progress
 ===========
+- Add support for Python 3.12
 
 2023-11-12 v0.1.1
 =================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ authors = [
   { name = "Andreas Motl", email = "andreas.motl@panodata.org" },
   { name = "Richard Pobering", email = "richard.pobering@panodata.org" },
 ]
-requires-python = ">=3.8,<3.12"
+requires-python = ">=3.8,<3.13"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
@@ -57,6 +57,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Communications",
   "Topic :: Database",
   "Topic :: Documentation",


### PR DESCRIPTION
What the title says.

Blocked by https://github.com/aio-libs/yarl/pull/942.
Blocks https://github.com/crate-workbench/cratedb-toolkit/pull/63.
