### PR TITLE
Dependencies: Use `dask[dataframe]`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ influxio changelog
 in progress
 ===========
 - Add support for Python 3.12
+- Dependencies: Use ``dask[dataframe]``
 
 2023-11-12 v0.1.1
 =================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
   "colorama<1",
   "crate[sqlalchemy]",
   "cratedb-toolkit",
-  "dask",
+  "dask[dataframe]>=2020,<=2024.2.1",
   'importlib-metadata; python_version <= "3.9"',
   "influxdb-client[ciso]<2",
   "line-protocol-parser<2",


### PR DESCRIPTION
## Problem

```python
>           import dask_expr  # noqa: F401
E           ModuleNotFoundError: No module named 'dask_expr'
```

-- https://github.com/crate-workbench/cratedb-toolkit/actions/runs/8258902237/job/22591947853#step:5:43

## References
- https://github.com/crate-workbench/cratedb-toolkit/pull/128
- https://github.com/microsoft/LightGBM/issues/6365
- https://github.com/microsoft/LightGBM/pull/6357
