### PR TITLE
Implement exporting line protocol data from InfluxDB API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ influxio changelog
 
 in progress
 ===========
+- Implement exporting line protocol data from InfluxDB API
 
 2024-03-22 v0.1.2
 =================

--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,11 @@ Export
         "http://example:token@localhost:8086/testdrive/demo" \
         "file://export.lp"
 
+    # From API to line protocol on stdout.
+    influxio copy \
+        "http://example:token@localhost:8086/testdrive/demo" \
+        "file://-?format=lp"
+
     # From data directory to line protocol file.
     influxio copy \
         "file:///path/to/data/engine?org=example&bucket=testdrive&measurement=demo" \

--- a/influxio/cli.py
+++ b/influxio/cli.py
@@ -50,6 +50,11 @@ def help_copy():
         http://example:token@localhost:8086/testdrive/demo \
         file://export.lp
 
+    # From API to line protocol on stdout.
+    influxio copy \
+        "http://example:token@localhost:8086/testdrive/demo" \
+        "file://-?format=lp"
+
     # From data directory to line protocol file.
     influxio copy \
         file:///path/to/data/engine?org=example&bucket=testdrive&measurement=demo \

--- a/influxio/core.py
+++ b/influxio/core.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from yarl import URL
 
-from influxio.model import InfluxDbAdapter, SqlAlchemyAdapter
+from influxio.model import FileAdapter, InfluxDbAdapter, SqlAlchemyAdapter
 from influxio.util.db import get_sqlalchemy_dialects
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,8 @@ def copy(source: str, target: str, progress: bool = False):
         sink = InfluxDbAdapter.from_url(target)
     elif scheme_primary in sqlalchemy_dialects:
         sink = SqlAlchemyAdapter.from_url(target, progress=True)
+    elif target_url.scheme == "file":
+        sink = FileAdapter.from_url(target, progress=True)
     else:
         raise NotImplementedError(f"Data sink not implemented: {target_url}")
 
@@ -63,7 +65,7 @@ def copy(source: str, target: str, progress: bool = False):
         sink.from_lineprotocol(path)
 
     elif source_url.scheme.startswith("http"):
-        if isinstance(sink, SqlAlchemyAdapter):
+        if isinstance(sink, (FileAdapter, SqlAlchemyAdapter)):
             source_node = InfluxDbAdapter.from_url(source)
             sink.write(source_node)
         else:

--- a/influxio/util/common.py
+++ b/influxio/util/common.py
@@ -4,6 +4,7 @@ import shlex
 import subprocess
 import sys
 import typing as t
+from enum import Enum
 from textwrap import dedent
 
 logger = logging.getLogger(__name__)
@@ -46,3 +47,16 @@ def run_command(command: str):
     else:
         if output:
             logger.info(f"Command output:\n{output}")
+
+
+class AutoStrEnum(str, Enum):
+    """
+    StrEnum where enum.auto() returns the field name.
+    See https://docs.python.org/3.9/library/enum.html#using-automatic-values
+
+    From https://stackoverflow.com/a/74539097.
+    """
+
+    @staticmethod
+    def _generate_next_value_(name: str, start: int, count: int, last_values: list) -> str:  # noqa: ARG004
+        return name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ dependencies = [
   "cratedb-toolkit",
   "dask[dataframe]>=2020,<=2024.3.1",
   'importlib-metadata; python_version <= "3.9"',
+  "influx-line==1.0.0",
   "influxdb-client[ciso]<2",
   "line-protocol-parser<2",
   "pandas<2.3",

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,4 +1,4 @@
-from influxio.model import SqlAlchemyAdapter
+from influxio.model import DataFormat, FileAdapter, SqlAlchemyAdapter
 
 
 def test_cratedb_adapter_void():
@@ -34,3 +34,15 @@ def test_cratedb_adapter_database_table():
     assert adapter.database == "testdrive"
     assert adapter.table == "basic"
     assert adapter.dburi == "crate://localhost:4200/?schema=testdrive"
+
+
+def test_file_adapter_ilp_file():
+    adapter = FileAdapter.from_url("file://foo.lp")
+    assert adapter.output.path == "foo.lp"
+    assert adapter.output.format is DataFormat.LINE_PROTOCOL
+
+
+def test_file_adapter_ilp_stdout():
+    adapter = FileAdapter.from_url("file://-?format=lp")
+    assert adapter.output.path == "-"
+    assert adapter.output.format is DataFormat.LINE_PROTOCOL

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -1,4 +1,7 @@
+from pathlib import Path
+
 import pytest
+from yarl import URL
 
 import influxio.core
 from influxio.model import InfluxDbAdapter, SqlAlchemyAdapter
@@ -6,6 +9,7 @@ from influxio.model import InfluxDbAdapter, SqlAlchemyAdapter
 CRATEDB_URL = "crate://crate@localhost:4200/testdrive/basic"
 INFLUXDB_URL = "http://example:token@localhost:8086/testdrive/basic"
 POSTGRESQL_URL = "postgresql+psycopg2://postgres@localhost:5432/testdrive/basic"
+ILP_URL_STDOUT = "file://-?format=lp"
 
 
 @pytest.fixture
@@ -34,6 +38,12 @@ def postgresql() -> SqlAlchemyAdapter:
     adapter = SqlAlchemyAdapter.from_url(POSTGRESQL_URL)
     adapter.create_database()
     return adapter
+
+
+@pytest.fixture
+def ilp_url_file(tmp_path) -> URL:
+    ilppath = tmp_path / "basic.lp"
+    return URL(f"file://{ilppath}")
 
 
 @pytest.fixture
@@ -110,3 +120,55 @@ def test_export_sqlite(caplog, influxdb, provision_influxdb, sqlite, sqlite_url)
     # Verify number of records in target database.
     records = sqlite.read_records()
     assert len(records) == 2
+
+
+def test_export_api_ilp_stdout(caplog, capsys, influxdb, provision_influxdb):
+    """
+    Verify exporting data from InfluxDB API to lineprotocol format (ILP) on STDOUT.
+    """
+
+    source_url = INFLUXDB_URL
+    target_url = ILP_URL_STDOUT
+
+    # Transfer data.
+    influxio.core.copy(source_url, target_url)
+
+    # Verify execution.
+    assert f"Copying from {source_url} to {target_url}" in caplog.messages
+    assert "Exporting dataframes in LINE_PROTOCOL format to -" in caplog.messages
+
+    # Verify records on stdout have the right shape.
+    out, err = capsys.readouterr()
+    assert (
+        out
+        == r"""
+basic,fruits=apple\,banana,id=1,name=foo price=0.42 1414747376000000000
+basic,fruits=pear,id=2,name=bar price=0.84 1414747378000000000
+""".lstrip()
+    )
+
+
+def test_export_api_ilp_file(caplog, capsys, influxdb, provision_influxdb, ilp_url_file):
+    """
+    Verify exporting data from InfluxDB API to lineprotocol format (ILP) into file.
+    """
+
+    source_url = INFLUXDB_URL
+    target_url = str(ilp_url_file)
+
+    # Transfer data.
+    influxio.core.copy(source_url, target_url)
+
+    # Verify execution.
+    assert f"Copying from {source_url} to {target_url}" in caplog.messages
+    assert f"Exporting dataframes in LINE_PROTOCOL format to {ilp_url_file.path}" in caplog.messages
+
+    # Verify records in file have the right shape.
+    out = Path(ilp_url_file.path).read_text()
+    assert (
+        out
+        == r"""
+basic,fruits=apple\,banana,id=1,name=foo price=0.42 1414747376000000000
+basic,fruits=pear,id=2,name=bar price=0.84 1414747378000000000
+""".lstrip()
+    )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,63 @@
+import pytest
+
+from influxio.model import DataFormat, OutputFile
+
+
+def test_data_format_from_name_success():
+    assert DataFormat.from_name("foo.lp") is DataFormat.LINE_PROTOCOL
+    assert DataFormat.from_name("foo.csv") is DataFormat.ANNOTATED_CSV
+
+
+def test_data_format_from_name_failure():
+    with pytest.raises(ValueError) as ex:
+        DataFormat.from_name("foo.bar")
+    assert ex.match("Unable to derive data format from file name: foo.bar")
+
+
+def test_data_format_from_url_filename_success():
+    assert DataFormat.from_url("file://foo.lp") is DataFormat.LINE_PROTOCOL
+    assert DataFormat.from_url("file://foo.csv") is DataFormat.ANNOTATED_CSV
+
+
+def test_data_format_from_url_filename_failure():
+    with pytest.raises(ValueError) as ex:
+        DataFormat.from_url("file://foo.bar")
+    assert ex.match("Unable to derive data format from URL filename or query parameter: file://foo.bar")
+
+
+def test_data_format_from_url_query_parameter_success():
+    assert DataFormat.from_url("file://-?format=lp") is DataFormat.LINE_PROTOCOL
+    assert DataFormat.from_url("file://-?format=csv") is DataFormat.ANNOTATED_CSV
+
+
+def test_data_format_from_url_query_parameter_failure_no_format():
+    with pytest.raises(ValueError) as ex:
+        DataFormat.from_url("file://-")
+    assert ex.match("Unable to derive data format from URL filename or query parameter: file://-")
+
+
+def test_data_format_from_url_query_parameter_failure_invalid_format():
+    with pytest.raises(NotImplementedError) as ex:
+        DataFormat.from_url("file://-?format=bar")
+    assert ex.match("Invalid data format: bar")
+
+
+def test_output_file_success_filename(tmp_path):
+    file_path = str(tmp_path.with_suffix(".lp").absolute())
+    of = OutputFile.from_url(f"file://{file_path}")
+    assert of.path == file_path
+    assert of.format is DataFormat.LINE_PROTOCOL
+    assert of.stream.name == file_path
+
+
+def test_output_file_success_query_parameter():
+    of = OutputFile.from_url("file://-?format=lp")
+    assert of.path == "-"
+    assert of.format is DataFormat.LINE_PROTOCOL
+    assert of.stream.fileno() == 6
+
+
+def test_output_file_failure_scheme(tmp_path):
+    with pytest.raises(NotImplementedError) as ex:
+        DataFormat.from_url("file://-?format=bar")
+    assert ex.match("Invalid data format: bar")


### PR DESCRIPTION
## About

Export line protocol data from InfluxDB API, using [influx-line](https://github.com/functionoffunction/influx-line) by @functionoffunction. Thank you so much!

## Synopsis

```shell
# From API to line protocol file.
influxio copy \
    "http://example:token@localhost:8086/testdrive/demo" \
    "file://export.lp"

# From API to line protocol on stdout.
influxio copy \
    "http://example:token@localhost:8086/testdrive/demo" \
    "file://-?format=lp"
```
