### PR TITLE
This and that

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ You can use ``influxio`` to import and export data into/from InfluxDB.
 It can be used both as a standalone program, and as a library.
 
 ``influxio`` is, amongst others, based on the excellent `dask`_, `fsspec`_,
-`influxdb-client`_, `line-protocol-parser`_, `pandas`_, and `SQLAlchemy`_
-packages.
+`influxdb-client`_, `influx-line`_, `line-protocol-parser`_, `pandas`_,
+and `SQLAlchemy`_ packages.
 
 Please note that ``influxio`` is alpha-quality software, and a work in progress.
 Contributions of all kinds are very welcome, in order to make it more solid.
@@ -248,6 +248,7 @@ There are a few other projects which are aiming at similar goals.
 .. _development: doc/development.rst
 .. _fsspec: https://pypi.org/project/fsspec/
 .. _influx: https://docs.influxdata.com/influxdb/latest/reference/cli/influx/
+.. _influx-line: https://github.com/functionoffunction/influx-line
 .. _influxd: https://docs.influxdata.com/influxdb/latest/reference/cli/influxd/
 .. _InfluxDB Fetcher: https://github.com/hgomez/influxdb
 .. _InfluxDB line protocol: https://docs.influxdata.com/influxdb/latest/reference/syntax/line-protocol/

--- a/README.rst
+++ b/README.rst
@@ -163,7 +163,7 @@ Export
     # From API to database file.
     influxio copy \
         "http://example:token@localhost:8086/testdrive/demo" \
-        "sqlite://export.sqlite?table=demo"
+        "sqlite:///export.sqlite?table=demo"
 
     # From API to database server.
     influxio copy \

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -6,26 +6,22 @@ influxio backlog
 ************
 Iteration +1
 ************
-- [x] Add project boilerplate
-- [x] Make it work
-- [x] Export to SQLite, PostgreSQL, and CrateDB
-- [x] Fix documentation about crate:// target
-- [x] Check if using a CrateDB schema works well
-- [x] Release 0.1.0
+- [o] Add annotated CSV export/import
+- [o] Address "TODO" items
+- [o] Fix ``.from_lineprotocol``
+- [o] Tests using ``assert_dataframe_equal``? Maybe in ``cratedb-toolkit``?
+- [o] Verify documentation. ``influxio.cli.help_copy``
+- [o] More refinements
 
 
 ************
 Iteration +2
 ************
-- [o] Fix ``.from_lineprotocol``
-- [o] Tests using ``assert_dataframe_equal``? Maybe in ``cratedb-toolkit``?
-- [o] Support InfluxDB 1.x
-- [o] Verify connecting to InfluxDB Cloud works well
 - [o] Fix ``cratedb_toolkit.sqlalchemy.patch_inspector()`` re. reflection of ``?schema=`` URL parameter
 - [o] Fix ``crate.client.sqlalchemy.dialect.DateTime`` re. ``TimezoneUnawareException``
+- [o] Verify connecting to InfluxDB Cloud works well
+- [o] Support InfluxDB 1.x
 - [o] Add Docker Compose file for auxiliary services
-- [o] Refinements
-- [o] Verify documentation. ``influxio.cli.help_copy``
 - [o] Refactor general purpose code to ``pueblo`` package
 - [o] Verify import and export of ILP and CSV files works well
 
@@ -40,8 +36,6 @@ Iteration +3
   - https://docs.influxdata.com/influxdb/v2.6/reference/syntax/annotated-csv/extended/
 - [o] Backends: python, cmdline, flux
 - [o] InfluxDB 1.x subscriptions?
-- [o] Line protocol builder
-  https://github.com/functionoffunction/influx-line
 - [o] cloud-to-cloud copy
 - [o] influxio list testdata://
 - [o] "SQLAlchemy » Dialects built-in" is broken
@@ -57,3 +51,14 @@ References
 - https://github.com/influxdata/flux/blob/e513f1483/stdlib/sql/sql_test.flux#L119-L173
 - https://github.com/influxdata/flux/blob/e513f1483/stdlib/universe/universe.flux#L1159-L1176
 - https://github.com/influxdata/flux/blob/e513f1483/stdlib/sql/to.go#L525
+
+
+****
+Done
+****
+- [x] Add project boilerplate
+- [x] Make it work
+- [x] Export to SQLite, PostgreSQL, and CrateDB
+- [x] Fix documentation about crate:// target
+- [x] Check if using a CrateDB schema works well
+- [x] Release 0.1.0

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -48,7 +48,7 @@ CrateDB
 
     docker run --rm -it --publish=4200:4200 \
         --volume="$PWD/var/lib/cratedb:/data" \
-        crate:5.6 -Cdiscovery.type=single-node
+        crate:latest -Cdiscovery.type=single-node
 
 - https://github.com/docker-library/docs/blob/master/crate/README.md
 

--- a/influxio/cli.py
+++ b/influxio/cli.py
@@ -38,7 +38,7 @@ def help_copy():
     # From API to database file.
     influxio copy \
         http://example:token@localhost:8086/testdrive/demo \
-        sqlite://export.sqlite
+        sqlite:///export.sqlite
 
     # From API to database server.
     influxio copy \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ markers = [
 [tool.ruff]
 line-length = 120
 
-select = [
+lint.select = [
   # Bandit
   "S",
   # Bugbear
@@ -183,7 +183,7 @@ select = [
   "RET",
 ]
 
-extend-ignore = [
+lint.extend-ignore = [
   # zip() without an explicit strict= parameter
   "B905",
   # df is a bad variable name. Be kinder to your future self.
@@ -194,7 +194,7 @@ extend-ignore = [
   "RET505",
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101"]  # Use of `assert` detected
 "influxio/util/report.py" = ["T201"]
 
@@ -221,7 +221,7 @@ format = [
 ]
 
 lint = [
-  { cmd = "ruff ." },
+  { cmd = "ruff check ." },
   { cmd = "black --check ." },
   { cmd = "validate-pyproject pyproject.toml" },
   # { cmd = "mypy" },


### PR DESCRIPTION
- Documentation: Fix SQLite export syntax
- Chore: Adjust configuration for more recent versions of Ruff
- Chore: Use `crate:latest` when advising a Docker command
- Chore: Update backlog
- Chore: Refer to `influx-line` package in README