### PR TITLE
Dask dependency and GitHub reStructuredText rendering fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,33 +2,41 @@
 influxio
 ########
 
-.. image:: https://github.com/daq-tools/influxio/actions/workflows/tests.yml/badge.svg
+.. start-badges
+
+|ci-tests| |ci-coverage| |license| |pypi-downloads|
+
+|python-versions| |status| |pypi-version|
+
+.. |ci-tests| image:: https://github.com/daq-tools/influxio/actions/workflows/tests.yml/badge.svg
     :target: https://github.com/daq-tools/influxio/actions/workflows/tests.yml
     :alt: Build status
 
-.. image:: https://codecov.io/gh/daq-tools/influxio/branch/main/graph/badge.svg
+.. |ci-coverage| image:: https://codecov.io/gh/daq-tools/influxio/branch/main/graph/badge.svg
     :target: https://app.codecov.io/gh/daq-tools/influxio
     :alt: Coverage
 
-.. image:: https://img.shields.io/pypi/v/influxio.svg
+.. |pypi-version| image:: https://img.shields.io/pypi/v/influxio.svg
     :target: https://pypi.org/project/influxio/
     :alt: PyPI Version
 
-.. image:: https://img.shields.io/pypi/pyversions/influxio.svg
+.. |python-versions| image:: https://img.shields.io/pypi/pyversions/influxio.svg
     :target: https://pypi.org/project/influxio/
     :alt: Python Version
 
-.. image:: https://img.shields.io/pypi/dw/influxio.svg
-    :target: https://pypi.org/project/influxio/
-    :alt: PyPI Downloads
+.. |pypi-downloads| image:: https://static.pepy.tech/badge/influxio/month
+    :target: https://www.pepy.tech/projects/influxio
+    :alt: PyPI Downloads per month
 
-.. image:: https://img.shields.io/pypi/status/influxio.svg
+.. |status| image:: https://img.shields.io/pypi/status/influxio.svg
     :target: https://pypi.org/project/influxio/
     :alt: Status
 
-.. image:: https://img.shields.io/pypi/l/influxio.svg
+.. |license| image:: https://img.shields.io/pypi/l/influxio.svg
     :target: https://pypi.org/project/influxio/
     :alt: License
+
+.. end-badges
 
 
 *****

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ dependencies = [
   "colorama<1",
   "crate[sqlalchemy]",
   "cratedb-toolkit",
-  "dask[dataframe]>=2020,<=2024.4.1",
+  "dask[dataframe]>=2020",
   'importlib-metadata; python_version <= "3.9"',
   "influx-line==1.0.0",
   "influxdb-client[ciso]<2",


### PR DESCRIPTION
## About
- Dependencies: Unpin upper version bound of `dask`.
  Otherwise, compatibility issues can not be resolved quickly, like with Python 3.11.9.
  See: https://github.com/dask/dask/issues/11038 
- README: Fix badges after GitHub changed their reStructuredText rendering

## References
- Unblocks https://github.com/crate-workbench/cratedb-toolkit/pull/135.