### PR TITLE
Last-minute fixes, robustness improvements, and documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,15 +62,15 @@ Synopsis
 
 .. code-block:: shell
 
-    # Export from data directory to line protocol format.
-    influxio copy \
-        "file:///path/to/data/engine?org=example&bucket=testdrive&measurement=demo" \
-        "file://export.lp"
-
     # Export from API to database.
     influxio copy \
         "http://example:token@localhost:8086/testdrive/demo" \
         "sqlite://export.sqlite?table=demo"
+
+    # Export from data directory to line protocol format.
+    influxio copy \
+        "file:///path/to/influxdb/engine?bucket-id=372d1908eab801a6&measurement=demo" \
+        "file://export.lp"
 
 
 **********

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+
+    project:
+      default:
+        target: 75%
+
+    patch:
+      default:
+        informational: true

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -6,13 +6,21 @@ influxio backlog
 ************
 Iteration +1
 ************
-- [o] Demonstrate "library use" in README
+- [o] README: Demonstrate "library use"
+- [o] README: Caveat about overwrite protection
+- [o] README: How to export from data directory using Docker?
+- [o] README: Add examples using InfluxDB Cloud
+- [o] README: Caveat when exporting unknown measurement from data directory:
+  It can not be detected.
+- [o] README: Inform about ``--verbose`` flag
 - [o] Publish documentation on RTD
 - [o] Add annotated CSV export/import
 - [o] Address "TODO" items
-- [o] Tests using ``assert_dataframe_equal``? Maybe in ``cratedb-toolkit``?
 - [o] Verify documentation. ``influxio.cli.help_copy``
 - [o] More refinements
+- [o] ``list-buckets`` subcommand, for both API and data directory
+- [o] Progress bars for non-Dask tasks
+- [o] Verbose by default?
 
 
 ************
@@ -20,11 +28,11 @@ Iteration +2
 ************
 - [o] Fix ``cratedb_toolkit.sqlalchemy.patch_inspector()`` re. reflection of ``?schema=`` URL parameter
 - [o] Fix ``crate.client.sqlalchemy.dialect.DateTime`` re. ``TimezoneUnawareException``
-- [o] Verify connecting to InfluxDB Cloud works well
 - [o] Support InfluxDB 1.x
 - [o] Add Docker Compose file for auxiliary services
 - [o] Refactor general purpose code to ``pueblo`` package
 - [o] Verify import and export of ILP and CSV files works well
+- [o] Tests using ``assert_dataframe_equal``? Maybe in ``cratedb-toolkit``?
 
 
 ************

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -20,7 +20,6 @@ Iteration +1
 - [o] More refinements
 - [o] ``list-buckets`` subcommand, for both API and data directory
 - [o] Progress bars for non-Dask tasks
-- [o] Verbose by default?
 
 
 ************
@@ -74,3 +73,4 @@ Done
 - [x] Fix ``.from_lineprotocol``
 - [x] Parameters bucket-id and measurement are obligatory on data
   directory export. Verify that.
+- [x] Be ``--verbose`` by default

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -6,8 +6,6 @@ influxio backlog
 ************
 Iteration +1
 ************
-- [o] Parameters bucket-id and measurement are obligatory on data directory export
-  Verify that.
 - [o] Demonstrate "library use" in README
 - [o] Publish documentation on RTD
 - [o] Add annotated CSV export/import
@@ -66,3 +64,5 @@ Done
 - [x] Check if using a CrateDB schema works well
 - [x] Release 0.1.0
 - [x] Fix ``.from_lineprotocol``
+- [x] Parameters bucket-id and measurement are obligatory on data
+  directory export. Verify that.

--- a/examples/export_lineprotocol.py
+++ b/examples/export_lineprotocol.py
@@ -45,8 +45,11 @@ def main():
     LINEPROTOCOL_FILE.parent.mkdir(parents=True, exist_ok=True)
 
     source_url = f"file://var/lib/influxdb2/engine?bucket-id={influx.bucket_id}&measurement={influx.measurement}"
+    target_url = f"file://{LINEPROTOCOL_FILE}"
+    logger.info(f"Source: {source_url}")
+    logger.info(f"Target: {target_url}")
     influx_data = InfluxDbEngineAdapter.from_url(source_url)
-    influx_data.to_lineprotocol(url=f"file://{LINEPROTOCOL_FILE}")
+    influx_data.to_lineprotocol(target_url)
 
     logger.info("Reading back data from lineprotocol file")
     with gzip.open(LINEPROTOCOL_FILE) as buffer:

--- a/influxio/adapter.py
+++ b/influxio/adapter.py
@@ -252,7 +252,7 @@ class InfluxDbEngineAdapter:
             tsm_file_count = report[0]["file_count"]
             wal_file_count = report[1]["file_count"]
             if tsm_file_count == 0 and wal_file_count == 0:
-                raise FileNotFoundError(r"Export yielded zero records")
+                raise FileNotFoundError(r"Export yielded zero records. Make sure to use a valid bucket-id.")
         else:
             raise NotImplementedError(f"Format is not supported: {format_}")
         if out.stdout:

--- a/influxio/cli.py
+++ b/influxio/cli.py
@@ -19,15 +19,15 @@ def help_copy():
     Synopsis
     ========
 
-    # Export from data directory to line protocol format.
-    influxio copy \
-        file:///path/to/data/engine?org=example&bucket=testdrive&measurement=demo \
-        file://export.lp
-
     # Export from API to database.
     influxio copy \
-        http://example:token@localhost:8086/testdrive/demo \
-        sqlite://export.sqlite
+        "http://example:token@localhost:8086/testdrive/demo" \
+        "sqlite://export.sqlite?table=demo"
+
+    # Export from data directory to line protocol format.
+    influxio copy \
+        "file:///path/to/influxdb/engine?bucket-id=372d1908eab801a6&measurement=demo" \
+        "file://export.lp"
 
     Examples
     ========

--- a/influxio/cli.py
+++ b/influxio/cli.py
@@ -127,7 +127,7 @@ def help_copy():
 
 @click.group()
 @click.version_option(package_name="influxio")
-@click.option("--verbose", is_flag=True, required=False, help="Turn on logging")
+@click.option("--verbose", is_flag=True, required=False, default=True, help="Turn on logging")
 @click.option("--debug", is_flag=True, required=False, help="Turn on logging with debug level")
 @click.pass_context
 def cli(ctx: click.Context, verbose: bool, debug: bool):

--- a/influxio/core.py
+++ b/influxio/core.py
@@ -69,9 +69,13 @@ def copy(source: str, target: str, progress: bool = False) -> t.Union[CommandRes
             source_path_dir = [path.name for path in Path(path).iterdir()]
             if "data" in source_path_dir and "wal" in source_path_dir:
                 source_element = InfluxDbEngineAdapter.from_url(source)
+                if not source_element.bucket_id:
+                    raise ValueError("Parameter missing or empty: bucket-id")
+                if not source_element.measurement:
+                    raise ValueError("Parameter missing or empty: measurement")
                 return source_element.to_lineprotocol(url=target_url)
             else:
-                raise NotImplementedError(f"Data source not implemented: {source_url}")
+                raise FileNotFoundError(f"No InfluxDB data directory: {path}")
 
         # Import
         else:

--- a/influxio/core.py
+++ b/influxio/core.py
@@ -6,6 +6,7 @@ from yarl import URL
 
 from influxio.adapter import FileAdapter, InfluxDbApiAdapter, InfluxDbEngineAdapter, SqlAlchemyAdapter
 from influxio.model import CommandResult
+from influxio.util.common import url_fullpath
 from influxio.util.db import get_sqlalchemy_dialects
 
 logger = logging.getLogger(__name__)
@@ -64,7 +65,7 @@ def copy(source: str, target: str, progress: bool = False) -> t.Union[CommandRes
 
         # Export
         if target_url.scheme == "file":
-            path = source_url.host + source_url.path
+            path = url_fullpath(source_url)
             source_path_dir = [path.name for path in Path(path).iterdir()]
             if "data" in source_path_dir and "wal" in source_path_dir:
                 source_element = InfluxDbEngineAdapter.from_url(source)

--- a/influxio/util/common.py
+++ b/influxio/util/common.py
@@ -69,7 +69,8 @@ def url_fullpath(url: URL):
     fullpath = url.host or ""
     if fullpath == "-":
         return fullpath
-    return fullpath + (url.path or "")
+    fullpath += url.path or ""
+    return fullpath.rstrip("/")
 
 
 def url_or_path(url: URL):

--- a/influxio/util/common.py
+++ b/influxio/util/common.py
@@ -48,7 +48,9 @@ def run_command(command: str) -> subprocess.CompletedProcess:
         raise
     else:
         if output:
-            logger.info(f"Command stderr:\n{output.stderr.decode('utf-8')}")
+            stderr = output.stderr.decode("utf-8")
+            if stderr:
+                logger.info(f"Command stderr:\n{stderr}")
         return output
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -247,3 +247,33 @@ def test_export_directory_ilp_file(caplog, capsys, influxdb, provision_influxdb,
     out = Path(ilp_url_file.path).read_text()
     assert "basic,fruits=pear,id=2,name=bar price=0.84 1414747378000000000" in out
     assert r"basic,fruits=apple\,banana,id=1,name=foo price=0.42 1414747376000000000" in out
+
+
+def test_export_directory_fail_wrong_path(tmp_path):
+
+    if "CI" in os.environ:
+        raise pytest.skip("Needs access to InfluxDB data directory")
+
+    with pytest.raises(FileNotFoundError) as ex:
+        influxio.core.copy(f"file://{tmp_path}", ILP_URL_STDOUT)
+    assert ex.match(f"No InfluxDB data directory: {tmp_path}")
+
+
+def test_export_directory_fail_bucket_id_missing():
+
+    if "CI" in os.environ:
+        raise pytest.skip("Needs access to InfluxDB data directory")
+
+    with pytest.raises(ValueError) as ex:
+        influxio.core.copy("file://var/lib/influxdb2/engine", ILP_URL_STDOUT)
+    assert ex.match("Parameter missing or empty: bucket-id")
+
+
+def test_export_directory_fail_measurement_missing():
+
+    if "CI" in os.environ:
+        raise pytest.skip("Needs access to InfluxDB data directory")
+
+    with pytest.raises(ValueError) as ex:
+        influxio.core.copy("file://var/lib/influxdb2/engine?bucket-id=fc6bb114ceb3ac0b", ILP_URL_STDOUT)
+    assert ex.match("Parameter missing or empty: measurement")


### PR DESCRIPTION
- URL vs. path computation fixes
- Data directory export: Verify parameters bucket-id and measurement
  They must be given, and not empty. Otherwise, no data slot can be addressed for input.
- Documentation: InfluxDB API first, data directory second
- Add Codecov configuration, with relaxed settings
- Be `--verbose` by default
- Chore: Don't log stderr from subcommands when empty