### PR TITLE
Fix CrateDB Cloud connectivity

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 
 in progress
 ===========
+- Fix CrateDB Cloud connectivity by propagating ``ssl=true`` query argument
 
 2024-04-10 v0.2.0
 =================

--- a/README.rst
+++ b/README.rst
@@ -211,6 +211,19 @@ Export from API
         "http://example:token@localhost:8086/testdrive/demo" \
         "file://-?format=lp"
 
+Export from Cloud to Cloud
+--------------------------
+
+.. code-block:: shell
+
+    # From InfluxDB Cloud to CrateDB Cloud.
+    influxio copy \
+        "https://8e9ec869a91a3517:T268DVLDHD8AJsjzOEluu...Pic4A==@eu-central-1-1.aws.cloud2.influxdata.com/testdrive/demo" \
+        "crate://admin:dZ,Y18*Z...7)6LqB@green-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200/testdrive/demo?ssl=true"
+
+    crash \
+        --hosts 'https://admin:dZ,Y18*Z...7)6LqB@green-shaak-ti.eks1.eu-west-1.aws.cratedb.net:4200' \
+        --command 'SELECT * FROM testdrive.demo;'
 
 Export from data directory
 --------------------------

--- a/influxio/adapter.py
+++ b/influxio/adapter.py
@@ -276,9 +276,14 @@ class SqlAlchemyAdapter:
         # Special handling for SQLite and CrateDB databases.
         self.dburi = str(url.with_query(None))
         if url.scheme == "crate":
+            query_args_passthrough = ["ssl"]
+            query = url.query
             url = url.with_path("")
             if self.database:
-                url = url.with_query({"schema": self.database})
+                url = url.update_query({"schema": self.database})
+                for arg in query_args_passthrough:
+                    if arg in query:
+                        url = url.update_query({arg: query[arg]})
             self.dburi = str(url)
         elif url.scheme == "sqlite":
             self.dburi = self.dburi.replace("sqlite:/", "sqlite:///")

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -16,6 +16,13 @@ def test_cratedb_adapter_universal_notation():
     assert adapter.dburi == "crate://localhost:4200/?schema=testdrive"
 
 
+def test_cratedb_adapter_with_ssl():
+    adapter = SqlAlchemyAdapter.from_url("crate://localhost:4200/testdrive/basic?ssl=true")
+    assert adapter.database == "testdrive"
+    assert adapter.table == "basic"
+    assert adapter.dburi == "crate://localhost:4200/?schema=testdrive&ssl=true"
+
+
 def test_cratedb_adapter_table():
     adapter = SqlAlchemyAdapter.from_url("crate://localhost:4200/?table=basic")
     assert adapter.database is None


### PR DESCRIPTION
## About
By supporting to propagate input database parameters to SQLAlchemy, like `ssl=true`, this patch fixes the connectivity problem with CrateDB Cloud.


## References
- GH-125
- https://github.com/crate/cratedb-guide/issues/86#issuecomment-2137798121
