### PR TITLE
Dependencies: Migrate from `crate[sqlalchemy]` to `sqlalchemy-cratedb`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 
 in progress
 ===========
+- Dependencies: Migrate from ``crate[sqlalchemy]`` to ``sqlalchemy-cratedb``
 
 2024-05-30 v0.2.1
 =================

--- a/influxio/io.py
+++ b/influxio/io.py
@@ -125,7 +125,10 @@ def dataframe_to_sql(
         patch_inspector()
 
         # Use performance INSERT method.
-        from crate.client.sqlalchemy.support import insert_bulk
+        try:
+            from sqlalchemy_cratedb.support import insert_bulk
+        except ImportError:  # pragma: nocover
+            from crate.client.sqlalchemy.support import insert_bulk
 
         method = insert_bulk
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,6 @@ dynamic = [
 dependencies = [
   "click<9",
   "colorama<1",
-  "crate[sqlalchemy]",
   "cratedb-toolkit",
   "dask[dataframe]>=2020",
   'importlib-metadata; python_version <= "3.9"',
@@ -96,6 +95,7 @@ dependencies = [
   "pandas<2.3",
   "psycopg2-binary<3",
   "pueblo>=0.0.7",
+  "sqlalchemy-cratedb",
   "SQLAlchemy-Utils<0.42",
   "yarl<2",
 ]


### PR DESCRIPTION
## About
The [CrateDB SQLAlchemy dialect](https://github.com/crate-workbench/sqlalchemy-cratedb) needs more love, so it was separated from the [DBAPI HTTP driver](https://github.com/crate/crate-python). This patch verifies and concludes the migration.

## References
- https://github.com/crate/roadmap/issues/85
