### PR TITLE
SQLAlchemy Dialect: Dependencies: Use `sqlalchemy-cratedb>=0.37`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.idea
 /.venv*
 /dist
+/doc/_build
 /tmp
 /var
 .DS_Store

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 
 in progress
 ===========
+- SQLAlchemy Dialect: Dependencies: Use `sqlalchemy-cratedb>=0.37.0`
+  This includes the fix to the `get_table_names()` reflection method.
 
 2024-06-11 v0.3.0
 =================

--- a/doc/backlog.rst
+++ b/doc/backlog.rst
@@ -25,7 +25,6 @@ Iteration +1
 ************
 Iteration +2
 ************
-- [o] Fix ``cratedb_toolkit.sqlalchemy.patch_inspector()`` re. reflection of ``?schema=`` URL parameter
 - [o] Fix ``crate.client.sqlalchemy.dialect.DateTime`` re. ``TimezoneUnawareException``
 - [o] Support InfluxDB 1.x and 3.x
 - [o] Add Docker Compose file for auxiliary services

--- a/influxio/io.py
+++ b/influxio/io.py
@@ -119,10 +119,6 @@ def dataframe_to_sql(
         pbar.register()
 
     if dburi.startswith("crate"):
-        # TODO: Submit patch to upstream `crate-python`. This is another proof that something is wrong.
-        from cratedb_toolkit.sqlalchemy import patch_inspector
-
-        patch_inspector()
 
         # Use performance INSERT method.
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ dependencies = [
   "pandas<2.3",
   "psycopg2-binary<3",
   "pueblo>=0.0.7",
-  "sqlalchemy-cratedb",
+  "sqlalchemy-cratedb>=0.37,<1",
   "SQLAlchemy-Utils<0.42",
   "yarl<2",
 ]


### PR DESCRIPTION
## About
This includes the fix to the `get_table_names()` reflection method, so it is no longer applicable to apply the monkeypatch from CrateDB Toolkit.

## Details
Needed to unblock another downstream patch.

- https://github.com/crate-workbench/cratedb-toolkit/pull/94