### PR TITLE
Dask interface: Accept and forward the new `if-exists` query parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 
 in progress
 ===========
+- Dask interface: Accept and forward the new ``if-exists`` URL query
+  parameter to Dask's ``to_sql()`` method.
 
 2024-06-13 v0.3.1
 =================

--- a/README.rst
+++ b/README.rst
@@ -287,6 +287,29 @@ keystrokes on subsequent invocations.
     influxio copy "${SOURCE}" "${TARGET}"
 
 
+Parameters
+==========
+
+``if-exists``
+-------------
+When targeting the SQLAlchemy database interface, the target table will be
+created automatically, if it does not exist. The ``if-exists`` URL query
+parameter can be used to configure this behavior. The default value is
+``fail``.
+
+* fail: Raise a ValueError.
+* replace: Drop the table before inserting new values.
+* append: Insert new values to the existing table.
+
+Example usage:
+
+.. code-block:: shell
+
+    influxio copy \
+        "http://example:token@localhost:8086/testdrive/demo" \
+        "crate://crate@localhost:4200/testdrive?table=demo&if-exists=replace"
+
+
 *******************
 Project information
 *******************

--- a/examples/export_sqlalchemy.py
+++ b/examples/export_sqlalchemy.py
@@ -41,7 +41,7 @@ def main():
     logger.info("Transferring data")
     for df in influx.read_df():
         logger.info("Loading data frame into RDBMS/SQL database using pandas/Dask")
-        dataframe_to_sql(df, dburi=DBURI, tablename="demo", progress=True)
+        dataframe_to_sql(df, dburi=DBURI, tablename="demo", if_exists="replace", progress=True)
 
     # Read back data from target database.
     logger.info("Reading back data from the target database")

--- a/influxio/io.py
+++ b/influxio/io.py
@@ -97,7 +97,7 @@ def dataframe_to_sql(
     tablename: str,
     index=False,
     chunksize=None,
-    if_exists="replace",
+    if_exists="fail",
     npartitions: int = None,
     progress: bool = False,
 ):
@@ -105,10 +105,18 @@ def dataframe_to_sql(
     Load pandas dataframe into database using Dask.
 
     https://stackoverflow.com/questions/62404502/using-dasks-new-to-sql-for-improved-efficiency-memory-speed-or-alternative-to
+
+    if_exists : {'fail', 'replace', 'append'}, default 'fail'
+        How to behave if the table already exists.
+
+        * fail: Raise a ValueError.
+        * replace: Drop the table before inserting new values.
+        * append: Insert new values to the existing table.
     """
     import dask.dataframe as dd
 
     # Set a few defaults.
+    if_exists = if_exists or "fail"
     chunksize = chunksize or 5_000
     npartitions = npartitions or int(os.cpu_count() / 2)
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -42,6 +42,15 @@ def test_cratedb_adapter_database_table():
     assert adapter.database == "testdrive"
     assert adapter.table == "basic"
     assert adapter.dburi == "crate://localhost:4200/?schema=testdrive"
+    assert adapter.if_exists is None
+
+
+def test_cratedb_adapter_if_exists():
+    adapter = SqlAlchemyAdapter.from_url("crate://localhost:4200/?database=testdrive&table=basic&if-exists=append")
+    assert adapter.database == "testdrive"
+    assert adapter.table == "basic"
+    assert adapter.dburi == "crate://localhost:4200/?schema=testdrive"
+    assert adapter.if_exists == "append"
 
 
 def test_file_adapter_ilp_file():


### PR DESCRIPTION
## About

The new `if-exists` query parameter will be forwarded to Dask's `to_sql()` method. By default, `influxio` will use `fail`.

## Details

When targeting the SQLAlchemy database interface, the target table will be created automatically, if it does not exist. The `if-exists` URL query parameter can be used to configure this behavior. The default value is `fail`.

* fail: Raise a ValueError.
* replace: Drop the table before inserting new values.
* append: Insert new values to the existing table.

## Example usage

```shell
influxio copy \
    "http://example:token@localhost:8086/testdrive/demo" \
    "crate://crate@localhost:4200/testdrive?table=demo&if-exists=replace"
```

## References
- https://github.com/crate-workbench/cratedb-toolkit/issues/148

