### PR TITLE
Unlock loading ILP data into SQLAlchemy databases, from filesystem and HTTP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 
 in progress
 ===========
+- Unlock loading ILP files into SQLAlchemy databases
 
 2024-06-23 v0.4.0
 =================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 in progress
 ===========
 - Unlock loading ILP files into SQLAlchemy databases
+- Unlock loading ILP files from HTTP resources
 
 2024-06-23 v0.4.0
 =================

--- a/README.rst
+++ b/README.rst
@@ -227,6 +227,15 @@ Load data from InfluxDB files into any SQL database supported by SQLAlchemy.
         "file://export.lp" \
         "crate://crate@localhost:4200/testdrive/demo"
 
+    # From remote line protocol file to SQLite.
+    influxio copy \
+        "https://github.com/influxdata/influxdb2-sample-data/raw/master/air-sensor-data/air-sensor-data.lp" \
+        "sqlite:///export.sqlite?table=air-sensor-data"
+
+    # From remote line protocol file to CrateDB.
+    influxio copy \
+        "https://github.com/influxdata/influxdb2-sample-data/raw/master/air-sensor-data/air-sensor-data.lp" \
+        "crate://crate@localhost:4200/testdrive/demo"
 
 
 Export from Cloud to Cloud

--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,8 @@ Help
 Import
 ------
 
+Import data from different sources into InfluxDB Server.
+
 .. code-block:: shell
 
     # From test data to API.
@@ -180,14 +182,11 @@ Import
         "https://github.com/influxdata/influxdb2-sample-data/raw/master/air-sensor-data/air-sensor-data.lp" \
         "http://example:token@localhost:8086/testdrive/demo"
 
-    # From line protocol file to any database supported by SQLAlchemy.
-    influxio copy \
-        "file://export.lp" \
-        "sqlite://export.sqlite?table=export"
-
 
 Export from API
 ---------------
+
+Export data from InfluxDB Server into different sinks.
 
 .. code-block:: shell
 
@@ -199,7 +198,7 @@ Export from API
     # From API to database server.
     influxio copy \
         "http://example:token@localhost:8086/testdrive/demo" \
-        "crate://crate@localhost:4200/testdrive?table=demo"
+        "crate://crate@localhost:4200/testdrive/demo"
 
     # From API to line protocol file.
     influxio copy \
@@ -210,6 +209,25 @@ Export from API
     influxio copy \
         "http://example:token@localhost:8086/testdrive/demo" \
         "file://-?format=lp"
+
+Load from File
+--------------
+
+Load data from InfluxDB files into any SQL database supported by SQLAlchemy.
+
+.. code-block:: shell
+
+    # From local line protocol file to SQLite.
+    influxio copy \
+        "file://export.lp" \
+        "sqlite:///export.sqlite?table=export"
+
+    # From local line protocol file to CrateDB.
+    influxio copy \
+        "file://export.lp" \
+        "crate://crate@localhost:4200/testdrive/demo"
+
+
 
 Export from Cloud to Cloud
 --------------------------
@@ -307,7 +325,7 @@ Example usage:
 
     influxio copy \
         "http://example:token@localhost:8086/testdrive/demo" \
-        "crate://crate@localhost:4200/testdrive?table=demo&if-exists=replace"
+        "crate://crate@localhost:4200/testdrive/demo?if-exists=replace"
 
 
 *******************

--- a/influxio/adapter.py
+++ b/influxio/adapter.py
@@ -14,7 +14,7 @@ from influxdb_client import InfluxDBClient
 from sqlalchemy_utils import create_database
 from yarl import URL
 
-from influxio.io import dataframe_to_lineprotocol, dataframe_to_sql
+from influxio.io import dataframe_from_lineprotocol, dataframe_to_lineprotocol, dataframe_to_sql
 from influxio.model import CommandResult, DataFormat, OutputFile
 from influxio.util.common import run_command, url_fullpath
 
@@ -371,6 +371,15 @@ class SqlAlchemyAdapter:
             if url.scheme == "crate" and not database:
                 database = url.query.get("schema")
         return database, table
+
+    def from_lineprotocol(self, source: t.Union[Path, str], precision: str = "ns"):
+        """
+        Load data from file in lineprotocol format (ILP).
+        """
+        logger.info(f"Loading line protocol file: {source}")
+        with open(source, "r") as fp:
+            df = dataframe_from_lineprotocol(fp)
+            self.write(df)
 
 
 class FileAdapter:

--- a/influxio/adapter.py
+++ b/influxio/adapter.py
@@ -10,8 +10,10 @@ import pandas as pd
 import psycopg2
 import sqlalchemy
 import sqlalchemy as sa
+from fsspec import filesystem
 from influxdb_client import InfluxDBClient
 from sqlalchemy_utils import create_database
+from upath import UPath
 from yarl import URL
 
 from influxio.io import dataframe_from_lineprotocol, dataframe_to_lineprotocol, dataframe_to_sql
@@ -374,10 +376,12 @@ class SqlAlchemyAdapter:
 
     def from_lineprotocol(self, source: t.Union[Path, str], precision: str = "ns"):
         """
-        Load data from file in lineprotocol format (ILP).
+        Load data from file or resource in lineprotocol format (ILP).
         """
-        logger.info(f"Loading line protocol file: {source}")
-        with open(source, "r") as fp:
+        logger.info(f"Loading line protocol data. source={source}")
+        p = UPath(source)
+        fs = filesystem(p.protocol, **p.storage_options)  # equivalent to p.fs
+        with fs.open(p.path) as fp:
             df = dataframe_from_lineprotocol(fp)
             self.write(df)
 

--- a/influxio/core.py
+++ b/influxio/core.py
@@ -85,11 +85,13 @@ def copy(source: str, target: str, progress: bool = False) -> t.Union[CommandRes
             sink.from_lineprotocol(path)
 
     elif source_url.scheme.startswith("http"):
-        if isinstance(sink, (FileAdapter, SqlAlchemyAdapter)):
+        # TODO: Improve dispatching.
+        source_url_str = str(source_url)
+        if isinstance(sink, (FileAdapter, SqlAlchemyAdapter)) and ".lp" not in source_url_str:
             source_node = InfluxDbApiAdapter.from_url(source)
             sink.write(source_node)
         else:
-            sink.from_lineprotocol(str(source_url))
+            sink.from_lineprotocol(source_url_str)
 
     else:
         raise NotImplementedError(f"Data source not implemented: {source_url}")

--- a/influxio/io.py
+++ b/influxio/io.py
@@ -113,6 +113,7 @@ def dataframe_to_sql(
         * replace: Drop the table before inserting new values.
         * append: Insert new values to the existing table.
     """
+    logger.info(f"Writing dataframe to SQL: uri={dburi}, table={tablename}")
     import dask.dataframe as dd
 
     # Set a few defaults.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ dependencies = [
   "cratedb-toolkit",
   "dask[dataframe]>=2020",
   'importlib-metadata; python_version <= "3.9"',
+  "fsspec[s3,http]",
   "influx-line==1.0.0",
   "influxdb-client[ciso]<2",
   "line-protocol-parser<2",
@@ -97,6 +98,7 @@ dependencies = [
   "pueblo>=0.0.7",
   "sqlalchemy-cratedb>=0.37,<1",
   "SQLAlchemy-Utils<0.42",
+  "universal-pathlib<0.3",
   "yarl<2",
 ]
 [project.optional-dependencies]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -79,7 +79,7 @@ def test_import_lineprotocol_url(line_protocol_url_basic, caplog):
 
     # Make sure database is purged.
     api = InfluxDbApiAdapter.from_url(target_url)
-    api.delete_measurement()
+    api.delete_bucket()
 
     # Transfer data.
     influxio.core.copy(source_url, target_url)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -21,7 +21,32 @@ def test_load_lineprotocol_to_sqlite_file(line_protocol_file_basic, caplog):
 
     # Verify execution.
     assert f"Copying from {source_url} to {target_url}" in caplog.messages
-    assert "Loading line protocol file: tests/testdata/basic.lp" in caplog.messages
+    assert "Loading line protocol data. source=tests/testdata/basic.lp" in caplog.messages
+
+    # Verify number of records in target database.
+    db = SqlAlchemyAdapter.from_url(target_url)
+    records = db.read_records()
+    assert len(records) == 2
+
+
+def test_load_lineprotocol_to_sqlite_url(line_protocol_url_basic, caplog):
+    """
+    Load line protocol URL into SQLite.
+    """
+
+    # Define source and target URLs.
+    source_url = line_protocol_url_basic
+    target_url = "sqlite:///export.sqlite?table=export"
+
+    # Make sure target database is purged.
+    Path("export.sqlite").unlink(missing_ok=True)
+
+    # Transfer data.
+    influxio.core.copy(source_url, target_url)
+
+    # Verify execution.
+    assert f"Copying from {source_url} to {target_url}" in caplog.messages
+    assert f"Loading line protocol data. source={line_protocol_url_basic}" in caplog.messages
 
     # Verify number of records in target database.
     db = SqlAlchemyAdapter.from_url(target_url)

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+import influxio.core
+from influxio.adapter import SqlAlchemyAdapter
+
+
+def test_load_lineprotocol_to_sqlite_file(line_protocol_file_basic, caplog):
+    """
+    Load line protocol file into SQLite.
+    """
+
+    # Define source and target URLs.
+    source_url = f"file://{line_protocol_file_basic}"
+    target_url = "sqlite:///export.sqlite?table=export"
+
+    # Make sure target database is purged.
+    Path("export.sqlite").unlink(missing_ok=True)
+
+    # Transfer data.
+    influxio.core.copy(source_url, target_url)
+
+    # Verify execution.
+    assert f"Copying from {source_url} to {target_url}" in caplog.messages
+    assert "Loading line protocol file: tests/testdata/basic.lp" in caplog.messages
+
+    # Verify number of records in target database.
+    db = SqlAlchemyAdapter.from_url(target_url)
+    records = db.read_records()
+    assert len(records) == 2


### PR DESCRIPTION
## About
Unlock code path for directly loading ILP data into databases supported by SQLAlchemy.
