### PR TITLE
API: Add `timeout` URL query parameter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changelog
 
 in progress
 ===========
+- API: Added ``timeout`` URL query parameter, using a default value of 60 seconds.
+  Thanks, @ZillKhan.
 
 2025-05-04 v0.5.1
 =================

--- a/README.rst
+++ b/README.rst
@@ -314,8 +314,28 @@ keystrokes on subsequent invocations.
     influxio copy "${SOURCE}" "${TARGET}"
 
 
-Parameters
-==========
+InfluxDB parameters
+===================
+
+``timeout``
+-----------
+The network timeout value is specified in seconds, the default value
+is 60 seconds. Both details deviate from the standard default setting
+of the underlying `InfluxDB client library <influxdb-client>`_, which
+uses milliseconds, and a default value of 10_000 milliseconds.
+
+If you need to adjust this setting, add the parameter ``timeout`` to
+the InfluxDB URL like this:
+
+.. code-block:: shell
+
+    influxio copy \
+        "http://example:token@localhost:8086/testdrive/demo?timeout=300" \
+        "crate://crate@localhost:4200/testdrive/demo"
+
+
+CrateDB parameters
+==================
 
 ``if-exists``
 -------------

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 
 import pytest
+import urllib3
 from yarl import URL
 
 import influxio.core
@@ -248,6 +249,20 @@ basic,fruits=apple\,banana,id=1,name=foo price=0.42 1414747376000000000
 basic,fruits=pear,id=2,name=bar price=0.84 1414747378000000000
 """.lstrip()
     )
+
+
+def test_export_api_ilp_timeout(caplog, capsys, influxdb, provision_influxdb):
+    """
+    Verify that the `timeout` option works.
+    """
+
+    source_url = INFLUXDB_API_URL + "?timeout=0.001"
+    target_url = ILP_URL_STDOUT
+
+    # Transfer data.
+    with pytest.raises(urllib3.exceptions.ReadTimeoutError) as ex:
+        influxio.core.copy(source_url, target_url)
+    assert ex.match("Read timed out.")
 
 
 def test_export_directory_ilp_stdout(caplog, capsys, influxdb, provision_influxdb):


### PR DESCRIPTION
## About
When reading larger data from the InfluxDB API, a read timeout may occur. This patch improves the program to make the spot configurable using the `timeout` URL query parameter. It uses a default value of 60 seconds.

## References
- GH-182
