### PR TITLE
OCI: Switch from Debian `bookworm` to `trixie`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 
 in progress
 ===========
+- OCI: Switched from Debian ``bookworm`` to ``trixie``
 
 2026-01-11 v0.7.0
 =================

--- a/release/oci/Dockerfile
+++ b/release/oci/Dockerfile
@@ -4,7 +4,7 @@
 # - https://vsupalov.com/buildkit-cache-mount-dockerfile/
 # - https://github.com/FernandoMiguel/Buildkit#mounttypecache
 
-FROM python:3.14-slim-bookworm
+FROM python:3.14-slim-trixie
 
 # Enable concurrent multi-arch builds.
 # https://github.com/docker/buildx/issues/549#issuecomment-1788297892


### PR DESCRIPTION
## About
Debian 13 "trixie" has been released on 9 August 2025.

## References
- GH-209