### PR TITLE
CI: Only push OCI image when permitted

### DIFF
--- a/.github/workflows/oci.yml
+++ b/.github/workflows/oci.yml
@@ -70,7 +70,6 @@ jobs:
   oci:
     needs: build_and_test
     runs-on: ubuntu-latest
-    if: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
 
     steps:
       - name: Acquire sources
@@ -127,7 +126,7 @@ jobs:
           platforms: linux/amd64,linux/arm64  #,linux/arm/v7
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          push: true
+          push: ${{ ! (startsWith(github.actor, 'dependabot') || github.event.pull_request.head.repo.fork ) }}
           cache-from: type=gha
           cache-to: type=gha,mode=max,compression=zstd
           sbom: true


### PR DESCRIPTION
Improve CI workflow.

- GH-214